### PR TITLE
Check for defaults loosely to allow falsy values

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -412,7 +412,7 @@ export function check(pretty = true) {
 		}
 
 		// Check if default is set
-		if (opts.default) {
+		if (opts.default != null) {
 			debug(`Setting ${name} to ${JSON.stringify(opts.default)}`);
 			process.env[name] = opts.default;
 			optional.push(name);


### PR DESCRIPTION
This small landmine caught me when I set a env-var default to `false`, rather than `"false"`, for a flag. This would also cause issues for `0` or other falsey values. 